### PR TITLE
Implemented Fijalist view + components across Fijalist + catalog pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-steps.md
-auth.md
-fix.md
+.vscode
 venv
+notes

--- a/backend/app/auth/routes/user.py
+++ b/backend/app/auth/routes/user.py
@@ -10,7 +10,32 @@ def get_user_data():
             "id": current_user.id,
             "username": current_user.username,
             "email": current_user.email,
-            "profile_picture": current_user.profile_picture
+            "profile_picture": current_user.profile_picture,
+            "collections": [{
+                "id": collection.id,
+                "name": collection.name,
+                "description": collection.description,
+                "is_private": collection.is_private,
+                "created_at": collection.created_at.isoformat(),
+                "updated_at": collection.updated_at.isoformat(),
+                "fijalists": [
+                    {
+                        "id": fijalist.id,
+                        "title": fijalist.title,
+                        "description": fijalist.description,
+                        "cover_image": fijalist.cover_image,
+                        "content": fijalist.content,
+                        "tags": [
+                            {
+                                "id": tag.id,
+                                "name": tag.name,
+                            }
+                            for tag in fijalist.tags
+                        ]
+                    }
+                    for fijalist in collection.fijalists
+                ]
+            } for collection in current_user.collections]
         })
     else:
         return jsonify({"authenticated": False}), 200

--- a/backend/app/main/__init__.py
+++ b/backend/app/main/__init__.py
@@ -2,4 +2,4 @@ from flask import Blueprint
 
 main = Blueprint("main", __name__, url_prefix='/api')
 
-from .routes import home
+from .routes import home, fijalists, collections, users, tags

--- a/backend/app/main/routes/__init__.py
+++ b/backend/app/main/routes/__init__.py
@@ -1,1 +1,5 @@
 from .home import *
+from .fijalists import *
+from .collections import *
+from .tags import *
+from .users import *

--- a/backend/app/main/routes/collections.py
+++ b/backend/app/main/routes/collections.py
@@ -23,7 +23,14 @@ def get_collections():
                 "title": fijalist.title,
                 "description": fijalist.description,
                 "cover_image": fijalist.cover_image,
-                "content": fijalist.content
+                "content": fijalist.content,
+                "tags": [
+                    {
+                        "id": tag.id,
+                        "name": tag.name,
+                    }
+                    for tag in fijalist.tags
+                ]
             }
             for fijalist in collection.fijalists
         ]
@@ -46,7 +53,14 @@ def get_collection_with_fijalists(collection_id):
                 "title": fijalist.title,
                 "description": fijalist.description,
                 "cover_image": fijalist.cover_image,
-                "content": fijalist.content
+                "content": fijalist.content,
+                "tags": [
+                    {
+                        "id": tag.id,
+                        "name": tag.name,
+                    }
+                    for tag in fijalist.tags
+                ]
             }
             for fijalist in collection.fijalists
         ]

--- a/backend/app/main/routes/collections.py
+++ b/backend/app/main/routes/collections.py
@@ -1,0 +1,136 @@
+from flask import request, jsonify
+from flask_login import current_user, login_required
+
+from app.models.collection  import Collection
+from app.models.fijalist  import FijaList
+from app.extensions import db
+from app.main import main
+
+@main.route('/collections', methods=['GET'])
+def get_collections():
+    collections = Collection.query.all()
+    
+    return jsonify([{
+        "id": collection.id,
+        "name": collection.name,
+        "description": collection.description,
+        "is_private": collection.is_private,
+        "created_at": collection.created_at.isoformat(),
+        "updated_at": collection.updated_at.isoformat(),
+        "fijalists": [
+            {
+                "id": fijalist.id,
+                "title": fijalist.title,
+                "description": fijalist.description,
+                "cover_image": fijalist.cover_image,
+                "content": fijalist.content
+            }
+            for fijalist in collection.fijalists
+        ]
+    } for collection in collections]), 200
+
+@main.route('/collections/<int:collection_id>', methods=['GET'])
+def get_collection_with_fijalists(collection_id):
+    collection = Collection.query.get_or_404(collection_id)
+
+    return jsonify({
+        "id": collection.id,
+        "name": collection.name,
+        "description": collection.description,
+        "is_private": collection.is_private,
+        "created_at": collection.created_at.isoformat(),
+        "updated_at": collection.updated_at.isoformat(),
+        "fijalists": [
+            {
+                "id": fijalist.id,
+                "title": fijalist.title,
+                "description": fijalist.description,
+                "cover_image": fijalist.cover_image,
+                "content": fijalist.content
+            }
+            for fijalist in collection.fijalists
+        ]
+    }), 200
+
+
+@main.route('/collections/<int:collection_id>/fijalists/<int:fijalist_id>', methods=['POST'])
+@login_required
+def add_fijalist_to_collection(collection_id, fijalist_id):
+    collection = Collection.query.get_or_404(collection_id)
+
+    if collection.user_id != current_user.id:
+        return jsonify({"error": "Unauthorized"}), 403
+
+    fijalist = FijaList.query.get_or_404(fijalist_id)
+
+    collection.fijalists.append(fijalist)
+    db.session.commit()
+
+    return jsonify({"message": "FijaList added to collection"}), 200
+
+@main.route('/collections/<int:collection_id>/fijalists/<int:fijalist_id>', methods=['DELETE'])
+@login_required
+def remove_fijalist_from_collection(collection_id, fijalist_id):
+    collection = Collection.query.get_or_404(collection_id)
+
+    if collection.user_id != current_user.id:
+        return jsonify({"error": "Unauthorized"}), 403
+
+    fijalist = FijaList.query.get_or_404(fijalist_id)
+
+    if fijalist in collection.fijalists:
+        collection.fijalists.remove(fijalist)
+        db.session.commit()
+        return jsonify({"message": "FijaList removed from collection"}), 200
+    else:
+        return jsonify({"error": "FijaList not found in collection"}), 404
+
+
+@main.route('/collections', methods=['POST'])
+def create_collection():
+    data = request.get_json()
+
+    collection = Collection(
+        name=data.get('name'),
+        description=data.get('description'),
+        is_private=data.get('is_private'),
+    )
+
+    db.session.add(collection)
+    db.session.commit()
+
+    return jsonify({
+        "id": collection.id,
+        "name": collection.name,
+        "description": collection.description,
+        "is_private": collection.is_private,
+    }), 201
+
+
+@main.route('/collections/<int:id>', methods=['PUT'])
+def update_collection(id):
+    data = request.get_json()
+
+    collection = Collection.query.get_or_404(id)
+    collection.name = data.get('name', collection.name)
+    collection.description = data.get('description', collection.description)
+    collection.is_private = data.get('is_private', collection.is_private)
+
+    db.session.commit()
+
+    return jsonify({
+        "id": collection.id,
+        "name": collection.name,
+        "description": collection.description,
+        "is_private": collection.is_private,
+    }), 200
+
+
+@main.route('/collections/<int:id>', methods=['DELETE'])
+def delete_collection(id):
+    collection = Collection.query.get_or_404(id)
+
+    db.session.delete(collection)
+    db.session.commit()
+
+    return jsonify({"message": "Collection deleted successfully"}), 200

--- a/backend/app/main/routes/fijalists.py
+++ b/backend/app/main/routes/fijalists.py
@@ -1,0 +1,108 @@
+from flask import request, jsonify
+from app.models.fijalist  import FijaList
+from app.models.tag  import Tag
+from app.extensions import db
+from app.main import main
+
+@main.route('/fijalists', methods=['GET'])
+def get_fijalists():
+    fijalists = FijaList.query.all()
+
+    return jsonify([{
+        "id": fijalist.id,
+        "title": fijalist.title,
+        "description": fijalist.description,
+        "cover_image": fijalist.cover_image,
+        "content": fijalist.content,
+        "created_at": fijalist.created_at.isoformat(),
+        "updated_at":fijalist.updated_at.isoformat(),
+        "tags": [
+            {
+                "id": tag.id,
+                "name": tag.name,
+            }
+            for tag in fijalist.tags
+        ]
+    } for fijalist in fijalists]), 200
+
+@main.route('/fijalists/<int:id>', methods=['GET'])
+def get_fijalist(id):
+    fijalist = FijaList.query.get_or_404(id)
+
+    return jsonify({
+        "id": fijalist.id,
+        "title": fijalist.title,
+        "description": fijalist.description,
+        "cover_image": fijalist.cover_image,
+        "content": fijalist.content,
+        "created_at": fijalist.created_at.isoformat(),
+        "updated_at":fijalist.updated_at.isoformat(),
+        "tags": [
+            {
+                "id": tag.id,
+                "name": tag.name,
+            }
+            for tag in fijalist.tags
+        ]
+    }), 200
+
+@main.route('/fijalists', methods=['POST'])
+def create_fijalist():
+    data = request.get_json()
+
+    fijalist = FijaList(
+        title=data.get('title'),
+        description=data.get('description'),
+        cover_image=data.get('cover_image'),
+        content=data.get('content'),
+    )
+
+    db.session.add(fijalist)
+    db.session.commit()
+
+    return jsonify({
+        "id": fijalist.id,
+        "title": fijalist.title,
+        "description": fijalist.description,
+        "cover_image": fijalist.cover_image,
+        "content": fijalist.content
+    }), 201
+
+@main.route('/fijalists/<int:fijalist_id>/tags/<int:tag_id>', methods=['POST'])
+def add_tag_to_fijalilst(fijalist_id, tag_id):
+    fijalist = FijaList.query.get_or_404(fijalist_id)
+    tag = Tag.query.get_or_404(tag_id)
+
+    fijalist.tags.append(tag)
+    db.session.commit()
+
+    return jsonify({"message": "Tag added to Fijalist"}), 200
+
+@main.route('/fijalists/<int:id>', methods=['PUT'])
+def update_fijalist(id):
+    data = request.get_json()
+
+    fijalist = FijaList.query.get_or_404(id)
+    fijalist.title = data.get('title', fijalist.title)
+    fijalist.description = data.get('description', fijalist.description)
+    fijalist.cover_image = data.get('cover_image', fijalist.cover_image)
+    fijalist.content = data.get('content', fijalist.content)
+
+    db.session.commit()
+    return jsonify({
+        "id": fijalist.id,
+        "title": fijalist.title,
+        "description": fijalist.description,
+        "cover_image": fijalist.cover_image,
+        "content": fijalist.content
+    }), 200
+
+
+@main.route('/fijalists/<int:id>', methods=['DELETE'])
+def delete_fijalist(id):
+    fijalist = FijaList.query.get_or_404(id)
+
+    db.session.delete(fijalist)
+    db.session.commit()
+
+    return jsonify({"message": "FijaList deleted successfully"}), 200

--- a/backend/app/main/routes/tags.py
+++ b/backend/app/main/routes/tags.py
@@ -1,0 +1,76 @@
+from flask import request, jsonify
+from app.models.tag  import Tag
+from app.extensions import db
+from app.main import main
+
+@main.route('/tags', methods=['GET'])
+def get_tags():
+    tags = Tag.query.all()
+
+    return jsonify([{
+        "id": tag.id,
+        "name": tag.name,
+    } for tag in tags]), 200
+
+@main.route('/tags/<int:id>', methods=['GET'])
+def get_tag(id):
+    tag = Tag.query.get_or_404(id)
+
+    return jsonify({
+        "id": tag.id,
+        "name": tag.name
+    }), 200
+
+@main.route('/tags/<int:id>/fijalists', methods=['GET'])
+def get_tag_fijalists(id):
+    tag = Tag.query.get_or_404(id)
+
+    return jsonify([{
+        "id": fijalist.id,
+        "title": fijalist.title,
+        "description": fijalist.description,
+        "cover_image": fijalist.cover_image,
+        "content": fijalist.content,
+        "created_at": fijalist.created_at.isoformat(),
+        "updated_at":fijalist.updated_at.isoformat(),
+    } for fijalist in tag.fijalists]), 200
+
+
+@main.route('/tags', methods=['POST'])
+def create_tag():
+    data = request.get_json()
+
+    tag = Tag(name=data.get('name'))
+
+    db.session.add(tag)
+    db.session.commit()
+
+    return jsonify({
+        "id": tag.id,
+        "name": tag.name,
+    }), 201
+
+
+@main.route('/tags/<int:id>', methods=['PUT'])
+def update_tag(id):
+    data = request.get_json()
+
+    tag = Tag.query.get_or_404(id)
+    tag.name = data.get('name', tag.name)
+
+    db.session.commit()
+    
+    return jsonify({
+        "id": tag.id,
+        "name": tag.name,
+    }), 200
+
+
+@main.route('/tags/<int:id>', methods=['DELETE'])
+def delete_tag(id):
+    tag = Tag.query.get_or_404(id)
+
+    db.session.delete(tag)
+    db.session.commit()
+
+    return jsonify({"message": "Tag deleted successfully"}), 200

--- a/backend/app/main/routes/users.py
+++ b/backend/app/main/routes/users.py
@@ -1,0 +1,109 @@
+
+from flask import request, jsonify
+
+from app.models.user  import User
+from app.models.collection  import Collection
+from app.extensions import db
+from app.main import main
+
+@main.route('/users', methods=['GET'])
+def get_users():
+    users = User.query.all
+
+    return jsonify([{
+        "id": user.id,
+        "username": user.username,
+        "email": user.email,
+        "profile_picture": user.profile_picture
+    } for user in users]), 200
+
+@main.route('/users/<int:id>', methods=['GET'])
+def get_user(id):
+    user = User.query.get_or_404(id)
+
+    return jsonify({
+        "id": user.id,
+        "username": user.username,
+        "email": user.email,
+        "profile_picture": user.profile_picture,
+    }), 200
+
+@main.route('/users/<int:id>/collections', methods=['GET'])
+def get_user_collections(id):
+    user = User.query.get_or_404(id)
+
+    return jsonify([{
+        "id": collection.id,
+        "name": collection.name,
+        "description": collection.description,
+        "is_private": collection.is_private,
+        "created_at": collection.created_at.isoformat(),
+        "updated_at": collection.updated_at.isoformat(),
+        "fijalists": [
+            {
+                "id": fijalist.id,
+                "title": fijalist.title,
+                "description": fijalist.description,
+                "cover_image": fijalist.cover_image,
+                "content": fijalist.content
+            }
+            for fijalist in collection.fijalists
+        ]
+    } for collection in user.collections]), 200
+
+@main.route('/users/<int:user_id>/collections/<int:collection_id>', methods=['GET'])
+def get_user_collection(user_id, collection_id):
+    user = User.query.get_or_404(user_id)
+    collection = Collection.query.get_or_404(collection_id)
+
+    if collection in user.collections:
+        return jsonify({
+        "id": collection.id,
+        "name": collection.name,
+        "description": collection.description,
+        "is_private": collection.is_private,
+        "created_at": collection.created_at.isoformat(),
+        "updated_at": collection.updated_at.isoformat(),
+        "fijalists": [
+            {
+                "id": fijalist.id,
+                "title": fijalist.title,
+                "description": fijalist.description,
+                "cover_image": fijalist.cover_image,
+                "content": fijalist.content
+            }
+            for fijalist in collection.fijalists
+        ]
+    }), 200
+    else:
+        return jsonify({"error": "Collection does not belong to user"}), 404
+
+
+
+@main.route('/users/<int:id>', methods=['PUT'])
+def update_user(id):
+    data = request.get_json()
+
+    user = User.query.get_or_404(id)
+    user.username = data.get('username', user.username)
+    user.email = data.get('email', user.email)
+    user.profile_picture = data.get('profile_picture', user.profile_picture)
+
+    db.session.commit()
+
+    return jsonify({
+        "id": user.id,
+        "username": user.username,
+        "email": user.email,
+        "profile_picture": user.profile_picture,
+    }), 200
+
+
+@main.route('/users/<int:id>', methods=['DELETE'])
+def delete_user(id):
+    user = User.query.get_or_404(id)
+
+    db.session.delete(user)
+    db.session.commit()
+
+    return jsonify({"message": "User deleted successfully"}), 200

--- a/backend/app/main/routes/users.py
+++ b/backend/app/main/routes/users.py
@@ -26,6 +26,31 @@ def get_user(id):
         "username": user.username,
         "email": user.email,
         "profile_picture": user.profile_picture,
+        "collections": [{
+                "id": collection.id,
+                "name": collection.name,
+                "description": collection.description,
+                "is_private": collection.is_private,
+                "created_at": collection.created_at.isoformat(),
+                "updated_at": collection.updated_at.isoformat(),
+                "fijalists": [
+                    {
+                        "id": fijalist.id,
+                        "title": fijalist.title,
+                        "description": fijalist.description,
+                        "cover_image": fijalist.cover_image,
+                        "content": fijalist.content,
+                        "tags": [
+                            {
+                                "id": tag.id,
+                                "name": tag.name,
+                            }
+                            for tag in fijalist.tags
+                        ]
+                    }
+                    for fijalist in collection.fijalists
+                ]
+            } for collection in user.collections]
     }), 200
 
 @main.route('/users/<int:id>/collections', methods=['GET'])
@@ -45,7 +70,14 @@ def get_user_collections(id):
                 "title": fijalist.title,
                 "description": fijalist.description,
                 "cover_image": fijalist.cover_image,
-                "content": fijalist.content
+                "content": fijalist.content,
+                "tags": [
+                    {
+                        "id": tag.id,
+                        "name": tag.name,
+                    }
+                    for tag in fijalist.tags
+                ]
             }
             for fijalist in collection.fijalists
         ]
@@ -70,7 +102,14 @@ def get_user_collection(user_id, collection_id):
                 "title": fijalist.title,
                 "description": fijalist.description,
                 "cover_image": fijalist.cover_image,
-                "content": fijalist.content
+                "content": fijalist.content,
+                "tags": [
+                    {
+                        "id": tag.id,
+                        "name": tag.name,
+                    }
+                    for tag in fijalist.tags
+                ]
             }
             for fijalist in collection.fijalists
         ]

--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -17,3 +17,19 @@ html,
 main {
   @apply mx-auto px-6 md:px-8 py-12 max-w-screen-2xl;
 }
+
+/* animation classes */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fadeIn {
+  animation: fadeIn 0.2s ease-out forwards;
+}

--- a/frontend/app/components/FijalistPreview.tsx
+++ b/frontend/app/components/FijalistPreview.tsx
@@ -1,0 +1,67 @@
+import { Link } from "react-router";
+import type { Fijalist } from "~/lib/types";
+
+interface FijalistPreviewProps {
+  fijalist: Fijalist;
+  onClose: () => void;
+}
+
+export default function FijalistPreview({ fijalist, onClose }: FijalistPreviewProps) {
+  // helper to truncate content to a shorter preview
+  const truncateContent = (content: string, maxLength = 300) => {
+    if (content.length <= maxLength) return content;
+    return content.substring(0, maxLength) + "...";
+  };
+
+  return (
+    <div className="flex flex-col">
+      <div className="relative h-64 mb-4 rounded-lg overflow-hidden">
+        <img 
+          src={fijalist.cover_image || 'https://via.placeholder.com/800x400?text=No+Image'} 
+          alt={fijalist.title}
+          className="w-full h-full object-cover"
+        />
+      </div>
+      
+      <h2 className="text-2xl font-bold mb-2">{fijalist.title}</h2>
+      
+      {fijalist.tags && fijalist.tags.length > 0 && (
+        <div className="flex flex-wrap gap-2 mb-3">
+          {fijalist.tags.map(tag => (
+            <span 
+              key={tag.id}
+              className="px-3 py-1 bg-purple-100 text-purple-800 text-sm rounded-full"
+            >
+              {tag.name}
+            </span>
+          ))}
+        </div>
+      )}
+      
+      <p className="text-gray-600 mb-4">{fijalist.description}</p>
+      
+      <div className="prose mb-6">
+        <div className="whitespace-pre-wrap text-gray-700">
+          {truncateContent(fijalist.content)}
+        </div>
+      </div>
+      
+      <div className="flex justify-between mt-auto pt-4 border-t">
+        <button
+          onClick={onClose}
+          className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 cursor-pointer"
+        >
+          Close
+        </button>
+        
+        <Link
+          to={`/fijalist/${String(fijalist.id)}`}
+          className="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700"
+          onClick={onClose}
+        >
+          View Full List
+        </Link>
+      </div>
+    </div>
+  );
+} 

--- a/frontend/app/components/FijalistPreview.tsx
+++ b/frontend/app/components/FijalistPreview.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router";
 import type { Fijalist } from "~/lib/types";
+import { saveScrollPosition } from "../hooks/useScrollPosition";
 
 interface FijalistPreviewProps {
   fijalist: Fijalist;
@@ -11,6 +12,12 @@ export default function FijalistPreview({ fijalist, onClose }: FijalistPreviewPr
   const truncateContent = (content: string, maxLength = 300) => {
     if (content.length <= maxLength) return content;
     return content.substring(0, maxLength) + "...";
+  };
+
+  // handle click on the view full list button
+  const handleViewFullList = () => {
+    saveScrollPosition("catalog");
+    onClose();
   };
 
   return (
@@ -57,7 +64,7 @@ export default function FijalistPreview({ fijalist, onClose }: FijalistPreviewPr
         <Link
           to={`/fijalist/${String(fijalist.id)}`}
           className="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700"
-          onClick={onClose}
+          onClick={handleViewFullList}
         >
           View Full List
         </Link>

--- a/frontend/app/components/FilterBar.tsx
+++ b/frontend/app/components/FilterBar.tsx
@@ -1,0 +1,162 @@
+import { useState } from "react";
+
+// properly type the filter categories
+type FilterCategories = {
+  [key: string]: string[];
+};
+
+// filter categories with their respective tags
+const filterCategories: FilterCategories = {
+  "Trip Type": [
+    "For Solo Travelers",
+    "For Families",
+    "For Friends",
+    "Cultural Immersion",
+    "Sustainable Tourism",
+  ],
+  "Budget": [
+    "Budget-Friendly",
+    "Mid-Range",
+    "Luxury Indulgences",
+  ],
+  "Attractions": [
+    "Art Museum",
+    "Science Museum",
+    "Historical Landmarks",
+    "Architectural Wonders",
+    "Literary Landmarks",
+    "Hidden Gems",
+    "Photogenic Spots",
+  ],
+  "Experiences": [
+    "Dining",
+    "Culinary Discoveries",
+    "Night Experiences",
+    "Day Experiences",
+    "Indie Boutiques",
+    "Lofi Beats",
+    "Seasonal Specialties",
+  ],
+  "Endorsements": [
+    "Expert Endorsed",
+    "Local Favorite",
+  ],
+};
+
+// all tags flattened into a single array
+const allTags = Object.values(filterCategories).flat();
+
+type FilterBarProps = {
+  selectedFilters: string[];
+  setSelectedFilters: (filters: string[]) => void;
+};
+
+export default function FilterBar({ selectedFilters, setSelectedFilters }: FilterBarProps) {
+  const [activeCategoryTab, setActiveCategoryTab] = useState<string | null>(null);
+  
+  // toggle a tag selection
+  const toggleFilter = (tag: string) => {
+    if (selectedFilters.includes(tag)) {
+      setSelectedFilters(selectedFilters.filter(filter => filter !== tag));
+    } else {
+      setSelectedFilters([...selectedFilters, tag]);
+    }
+  };
+  
+  // toggle category tab visibility
+  const toggleCategoryTab = (category: string) => {
+    if (activeCategoryTab === category) {
+      setActiveCategoryTab(null);
+    } else {
+      setActiveCategoryTab(category);
+    }
+  };
+  
+  // clear all filters
+  const clearAllFilters = () => {
+    setSelectedFilters([]);
+    setActiveCategoryTab(null);
+  };
+  
+  return (
+    <div className="mb-6">
+      {/* main filter categories */}
+      <div className="flex space-x-2 mb-2 overflow-x-auto pb-2">
+        <button
+          onClick={clearAllFilters}
+          className={`px-4 py-2 text-sm font-medium rounded-full hover:bg-gray-200 ${
+            selectedFilters.length > 0 
+              ? "bg-purple-100 text-purple-600 hover:bg-purple-200" 
+              : "bg-gray-100"
+          }`}
+        >
+          {selectedFilters.length > 0 ? `Clear Filters (${selectedFilters.length})` : "Filters"}
+        </button>
+        
+        {Object.keys(filterCategories).map((category) => (
+          <button
+            key={category}
+            onClick={() => toggleCategoryTab(category)}
+            className={`px-4 py-2 text-sm font-medium rounded-full ${
+              activeCategoryTab === category
+                ? "bg-gray-200"
+                : selectedFilters.some(filter => filterCategories[category].includes(filter))
+                  ? "bg-purple-100 text-purple-600 hover:bg-purple-200"
+                  : "bg-gray-100 hover:bg-gray-200"
+            }`}
+          >
+            {category}
+            {selectedFilters.some(filter => filterCategories[category].includes(filter)) && 
+              ` (${selectedFilters.filter(filter => filterCategories[category].includes(filter)).length})`
+            }
+          </button>
+        ))}
+      </div>
+      
+      {/* expanded filter tag options */}
+      {activeCategoryTab && (
+        <div className="bg-white shadow-md rounded-lg p-4 mb-4 border animate-fadeIn">
+          <h3 className="text-sm font-medium mb-3">{activeCategoryTab}</h3>
+          <div className="flex flex-wrap gap-2">
+            {filterCategories[activeCategoryTab].map((tag: string) => (
+              <button
+                key={tag}
+                onClick={() => toggleFilter(tag)}
+                className={`px-3 py-1.5 text-sm rounded-full transition-colors ${
+                  selectedFilters.includes(tag)
+                    ? "bg-purple-100 text-purple-600 hover:bg-purple-200"
+                    : "bg-gray-100 hover:bg-gray-200"
+                }`}
+              >
+                {tag}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+      
+      {/* selected filters display */}
+      {selectedFilters.length > 0 && (
+        <div className="flex flex-wrap gap-2 mt-2">
+          {selectedFilters.map((filter) => (
+            <span 
+              key={filter} 
+              className="inline-flex items-center px-3 py-1 bg-purple-100 text-purple-600 rounded-full text-sm"
+            >
+              {filter}
+              <button 
+                onClick={() => toggleFilter(filter)}
+                className="ml-1.5 text-purple-500 hover:text-purple-700"
+                aria-label={`Remove ${filter} filter`}
+              >
+                <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+} 

--- a/frontend/app/components/FilterBar.tsx
+++ b/frontend/app/components/FilterBar.tsx
@@ -82,16 +82,14 @@ export default function FilterBar({ selectedFilters, setSelectedFilters }: Filte
     <div className="mb-6">
       {/* main filter categories */}
       <div className="flex space-x-2 mb-2 overflow-x-auto pb-2">
-        <button
-          onClick={clearAllFilters}
-          className={`px-4 py-2 text-sm font-medium rounded-full hover:bg-gray-200 ${
-            selectedFilters.length > 0 
-              ? "bg-purple-100 text-purple-600 hover:bg-purple-200" 
-              : "bg-gray-100"
-          }`}
-        >
-          {selectedFilters.length > 0 ? `Clear Filters (${selectedFilters.length})` : "Filters"}
-        </button>
+        {selectedFilters.length > 0 && (
+          <button
+            onClick={clearAllFilters}
+            className="px-4 py-2 text-sm font-medium rounded-full bg-purple-100 text-purple-600 hover:bg-purple-200"
+          >
+            Clear Filters ({selectedFilters.length})
+          </button>
+        )}
         
         {Object.keys(filterCategories).map((category) => (
           <button

--- a/frontend/app/components/LoadingSpinner.tsx
+++ b/frontend/app/components/LoadingSpinner.tsx
@@ -1,0 +1,12 @@
+export default function LoadingSpinner() {
+  return (
+    <div
+      className="flex justify-center my-8"
+      role="status"
+      aria-label="Loading"
+    >
+      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+      <span className="sr-only">Loading...</span>
+    </div>
+  );
+} 

--- a/frontend/app/components/MasonryGrid.tsx
+++ b/frontend/app/components/MasonryGrid.tsx
@@ -1,13 +1,13 @@
-import { Link } from "react-router";
 import type { Fijalist } from "~/lib/types";
 import { getRandomHeight } from "../utils/display";
 
 interface MasonryGridProps {
   items: Fijalist[];
   lastItemRef?: (node: HTMLDivElement | null) => void;
+  onItemClick: (item: Fijalist) => void;
 }
 
-export default function MasonryGrid({ items, lastItemRef }: MasonryGridProps) {
+export default function MasonryGrid({ items, lastItemRef, onItemClick }: MasonryGridProps) {
   return (
     <div className="columns-1 sm:columns-2 md:columns-3 gap-4 space-y-4">
       {items.map((item, index) => (
@@ -16,22 +16,23 @@ export default function MasonryGrid({ items, lastItemRef }: MasonryGridProps) {
           ref={index === items.length - 1 ? lastItemRef : null}
           className="break-inside-avoid mb-4"
         >
-          <Link to={`/fijalist/${String(item.id)}`}>
-            <div className="bg-white rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow">
-              <figure className="relative">
-                <img
-                  src={item.cover_image || 'https://via.placeholder.com/400x300?text=No+Image'}
-                  alt={item.title}
-                  className="w-full h-full object-cover"
-                  style={{ height: `${getRandomHeight()}rem` }}
-                />
-              </figure>
-              <div className="p-4">
-                <h3 className="font-semibold text-lg mb-1">{item.title}</h3>
-                <p className="text-sm text-gray-500">{item.description}</p>
-              </div>
+          <div 
+            className="bg-white rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+            onClick={() => onItemClick(item)}
+          >
+            <figure className="relative">
+              <img
+                src={item.cover_image || 'https://via.placeholder.com/400x300?text=No+Image'}
+                alt={item.title}
+                className="w-full h-full object-cover"
+                style={{ height: `${getRandomHeight()}rem` }}
+              />
+            </figure>
+            <div className="p-4">
+              <h3 className="font-semibold text-lg mb-1">{item.title}</h3>
+              <p className="text-sm text-gray-500">{item.description}</p>
             </div>
-          </Link>
+          </div>
         </article>
       ))}
     </div>

--- a/frontend/app/components/MasonryGrid.tsx
+++ b/frontend/app/components/MasonryGrid.tsx
@@ -1,0 +1,39 @@
+import { Link } from "react-router";
+import type { Fijalist } from "~/lib/types";
+import { getRandomHeight } from "../utils/display";
+
+interface MasonryGridProps {
+  items: Fijalist[];
+  lastItemRef?: (node: HTMLDivElement | null) => void;
+}
+
+export default function MasonryGrid({ items, lastItemRef }: MasonryGridProps) {
+  return (
+    <div className="columns-1 sm:columns-2 md:columns-3 gap-4 space-y-4">
+      {items.map((item, index) => (
+        <article
+          key={item.id}
+          ref={index === items.length - 1 ? lastItemRef : null}
+          className="break-inside-avoid mb-4"
+        >
+          <Link to={`/fijalist/${String(item.id)}`}>
+            <div className="bg-white rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow">
+              <figure className="relative">
+                <img
+                  src={item.cover_image || 'https://via.placeholder.com/400x300?text=No+Image'}
+                  alt={item.title}
+                  className="w-full h-full object-cover"
+                  style={{ height: `${getRandomHeight()}rem` }}
+                />
+              </figure>
+              <div className="p-4">
+                <h3 className="font-semibold text-lg mb-1">{item.title}</h3>
+                <p className="text-sm text-gray-500">{item.description}</p>
+              </div>
+            </div>
+          </Link>
+        </article>
+      ))}
+    </div>
+  );
+} 

--- a/frontend/app/components/Modal.tsx
+++ b/frontend/app/components/Modal.tsx
@@ -1,0 +1,108 @@
+import { useRef, useEffect } from "react";
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+  title?: string;
+}
+
+export default function Modal({ isOpen, onClose, children, title }: ModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  
+  // close modal when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    }
+    
+    // close modal when pressing escape
+    function handleEscKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+    
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      document.addEventListener("keydown", handleEscKey);
+      // prevent scrolling of background content
+      document.body.style.overflow = "hidden";
+    }
+    
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscKey);
+      document.body.style.overflow = "auto";
+    };
+  }, [isOpen, onClose]);
+  
+  if (!isOpen) return null;
+  
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
+        {/* background overlay */}
+        <div 
+          className="fixed inset-0 transition-opacity bg-gray-500 bg-opacity-75" 
+          aria-hidden="true"
+        ></div>
+        
+        {/* center modal */}
+        <span 
+          className="hidden sm:inline-block sm:align-middle sm:h-screen" 
+          aria-hidden="true"
+        >&#8203;</span>
+        
+        {/* modal content */}
+        <div 
+          ref={modalRef}
+          className="inline-block overflow-hidden text-left align-bottom transition-all transform bg-white rounded-lg shadow-xl sm:my-8 sm:align-middle sm:max-w-3xl sm:w-full"
+          role="dialog" 
+          aria-modal="true" 
+          aria-labelledby="modal-headline"
+        >
+          {/* modal header */}
+          <div className="flex items-center justify-between px-6 pt-5 pb-2 border-b">
+            {title && (
+              <h3 
+                className="text-lg font-medium text-gray-900" 
+                id="modal-headline"
+              >
+                {title}
+              </h3>
+            )}
+            
+            <button
+              type="button"
+              className="text-gray-400 hover:text-gray-500 focus:outline-none cursor-pointer"
+              onClick={onClose}
+              aria-label="Close"
+            >
+              <svg 
+                className="w-6 h-6" 
+                fill="none" 
+                viewBox="0 0 24 24" 
+                stroke="currentColor" 
+              >
+                <path 
+                  strokeLinecap="round" 
+                  strokeLinejoin="round" 
+                  strokeWidth="2" 
+                  d="M6 18L18 6M6 6l12 12" 
+                />
+              </svg>
+            </button>
+          </div>
+          
+          {/* modal body */}
+          <div className="px-6 py-4 max-h-[80vh] overflow-y-auto">
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/frontend/app/hooks/useData.tsx
+++ b/frontend/app/hooks/useData.tsx
@@ -1,0 +1,57 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import type { Fijalist } from "../lib/types";
+
+interface DataContextType {
+  isLoading: boolean;
+  error: string | null;
+  fijalists: Fijalist[];
+}
+
+const defaultContext: DataContextType = {
+  isLoading: true,
+  error: null,
+  fijalists: [],
+};
+
+const DataContext = createContext<DataContextType>(defaultContext);
+
+export function DataProvider({ children }: { children: React.ReactNode }) {
+  const BACKEND_URL = `${import.meta.env.VITE_BACKEND_URL}/api`;
+  const [fijalists, setFijalists] = useState<Fijalist[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchFijalists = async () => {
+      try {
+        const response = await fetch(`${BACKEND_URL}/fijalists`, {
+          credentials: "include",
+        });
+        if (!response.ok) throw new Error("Failed to fetch FijaLists");
+        const data = await response.json();
+        setFijalists(data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    fetchFijalists();
+    setIsLoading(false);
+  }, []);
+
+  return (
+    <DataContext.Provider
+      value={{
+        isLoading,
+        error,
+        fijalists,
+      }}
+    >
+      {children}
+    </DataContext.Provider>
+  );
+}
+
+export default function useData() {
+  return useContext(DataContext);
+}

--- a/frontend/app/hooks/useInfiniteScroll.ts
+++ b/frontend/app/hooks/useInfiniteScroll.ts
@@ -1,0 +1,71 @@
+import { useState, useRef, useCallback, useEffect } from "react";
+
+interface UseInfiniteScrollOptions<T> {
+  items: T[];
+  pageSize: number;
+  loadMore?: (items: T[]) => void;
+}
+
+export default function useInfiniteScroll<T>({ 
+  items, 
+  pageSize, 
+  loadMore 
+}: UseInfiniteScrollOptions<T>) {
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [displayedItems, setDisplayedItems] = useState<T[]>([]);
+  const observer = useRef<IntersectionObserver | null>(null);
+
+  // fetch items with pagination
+  const fetchItems = useCallback(async () => {
+    setLoading(true);
+    
+    // simulate loading delay
+    await new Promise(resolve => setTimeout(resolve, 300));
+    
+    const newItems = items.slice(0, page * pageSize);
+    
+    setDisplayedItems(newItems);
+    
+    if (loadMore) {
+      loadMore(newItems);
+    }
+    
+    setLoading(false);
+  }, [items, page, pageSize, loadMore]);
+
+  // load items when page changes or source items change
+  useEffect(() => {
+    fetchItems();
+  }, [fetchItems, page, items]);
+
+  // intersection observer reference to attach to last item
+  const lastItemRef = useCallback(
+    (node: HTMLElement | null) => {
+      if (loading) return;
+      
+      if (observer.current) observer.current.disconnect();
+      
+      observer.current = new IntersectionObserver(entries => {
+        if (entries[0].isIntersecting) {
+          if (page * pageSize >= items.length) {
+            observer.current?.disconnect();
+            return;
+          }
+          
+          setPage(prev => prev + 1);
+        }
+      });
+      
+      if (node) observer.current.observe(node);
+    },
+    [loading, page, pageSize, items.length]
+  );
+
+  return {
+    loading,
+    displayedItems,
+    lastItemRef,
+    hasMore: page * pageSize < items.length
+  };
+} 

--- a/frontend/app/hooks/useScrollPosition.ts
+++ b/frontend/app/hooks/useScrollPosition.ts
@@ -1,0 +1,27 @@
+// TO DISCUSS: what do we want when the user presses the "Back to catalog" button in the fijalist page?
+// do we want to save the scroll position and restore it when the user clicks the "Back to catalog" button?
+
+import { useEffect } from "react";
+
+// global object to store scroll positions by route
+const scrollPositions: Record<string, number> = {};
+
+// save current scroll position before leaving a route
+export function saveScrollPosition(route: string) {
+  scrollPositions[route] = window.scrollY;
+}
+
+// custom hook to restore scroll position when returning to a route
+export function useRestoreScrollPosition(route: string) {
+  useEffect(() => {
+    // check if we have a saved position for this route
+    if (scrollPositions[route] !== undefined) {
+      // use a small timeout to ensure the DOM has updated
+      const timer = setTimeout(() => {
+        window.scrollTo(0, scrollPositions[route]);
+      }, 0);
+      
+      return () => clearTimeout(timer);
+    }
+  }, [route]);
+} 

--- a/frontend/app/lib/types.ts
+++ b/frontend/app/lib/types.ts
@@ -1,8 +1,35 @@
-export interface User {
+interface User {
   id: string;
   username: string;
   email: string;
   profile_picture?: string | null;
-  created_at?: string;
-  updated_at?: string;
+  collections?: Collection[];
 }
+
+interface Collection {
+  id: string;
+  name: string;
+  description: string;
+  is_private: boolean;
+  fijalist?: Fijalist[];
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface Fijalist {
+  id: string;
+  title: string;
+  description: string;
+  content: string;
+  cover_image?: string;
+  tags?: Tag[];
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface Tag {
+  id: string;
+  name: string;
+}
+
+export type { User, Fijalist, Collection, Tag };

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -7,6 +7,7 @@ import {
   ScrollRestoration,
 } from "react-router";
 import { AuthProvider } from "./hooks/useAuth";
+import { DataProvider } from "./hooks/useData";
 import Navbar from "./components/navbar";
 import "./app.css";
 import Footer from "./components/footer";
@@ -45,12 +46,14 @@ export function Layout({ children }: { children: React.ReactNode }) {
       </head>
       <body>
         <AuthProvider>
-          <Navbar />
-          {children}
+          <DataProvider>
+            <Navbar />
+            {children}
+          </DataProvider>
         </AuthProvider>
         <ScrollRestoration />
         <Scripts />
-        <Footer/>
+        <Footer />
       </body>
     </html>
   );

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -7,4 +7,5 @@ export default [
   route("signup", "routes/signup.tsx"),
   route("profile", "routes/profile.tsx"),
   route("catalog", "routes/catalog.tsx"),
+  route("fijalist/:id", "routes/fijalist.tsx"),
 ] satisfies RouteConfig;

--- a/frontend/app/routes/catalog.tsx
+++ b/frontend/app/routes/catalog.tsx
@@ -1,59 +1,63 @@
 // TO DISCUSS: should a location be entered as a primary action in the main catalog page,
 // or do we not want to limit it to location?
 // TODO: upon clicking on a list, it should show up as a modal so we don't lose our position on the page
-// or similar to Pinterest where it opens up a new view, and recommends similar things underneath 
+// or similar to Pinterest where it opens up a new view, and recommends similar things underneath
 
-import { useState, useEffect, useRef, useCallback } from 'react';
-
-interface Item {
-  id: number;
-  height: number;
-}
+import { useState, useEffect, useRef, useCallback } from "react";
+import useData from "../hooks/useData";
+import type { Fijalist } from "~/lib/types";
 
 export default function Catalog() {
-  const [viewMode, setViewMode] = useState('grid'); // grid or map view
-  const [items, setItems] = useState<Item[]>([]);
+  const { fijalists } = useData();
+
+  const [viewMode, setViewMode] = useState("grid"); // grid or map view
+  const [items, setItems] = useState<Fijalist[]>(fijalists.slice(0, 10));
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(false);
   const observer = useRef<IntersectionObserver | null>(null);
-  
+
   // so that the grid can randomize heights bw 10rem and 30rem across the grid
   const getRandomHeight = () => Math.floor(Math.random() * (30 - 10 + 1) + 10);
-  
-  // simulate fetching data
+
   const fetchItems = useCallback(async () => {
     setLoading(true);
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    
-    const newItems = [...Array(12)].map((_, index) => ({
-      id: (page - 1) * 12 + index,
-      height: getRandomHeight()
-    }));
-    
-    setItems(prev => [...prev, ...newItems]);
-    setLoading(false);
-  }, [page]);
 
-  // initialize w first batch of items
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    const newItems = fijalists.slice((page - 1) * 10, page * 10);
+
+    setItems((prev) => [...prev, ...newItems]);
+
+    setLoading(false);
+  }, [page, fijalists]);
+
   useEffect(() => {
     fetchItems();
-  }, [page]);
+  }, [page, fijalists]);
 
-  // set up intersection observer for infinite scroll (this part is called the observer - InstersectionObserver is an api that is used to detect 
+  // set up intersection observer for infinite scroll (this part is called the observer - InstersectionObserver is an api that is used to detect
   // when a user scrolls to the bottom of page)
-  const lastItemRef = useCallback((node: HTMLDivElement | null) => {
-    if (loading) return;
-    
-    if (observer.current) observer.current.disconnect();
-    
-    observer.current = new IntersectionObserver(entries => {
-      if (entries[0].isIntersecting) {
-        setPage(prev => prev + 1);
-      }
-    });
-    
-    if (node) observer.current.observe(node);
-  }, [loading]);
+  const lastItemRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (loading) return;
+
+      if (observer.current) observer.current.disconnect();
+
+      observer.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting) {
+          if (page * 10 >= fijalists.length) {
+            observer.current?.disconnect();
+            return;
+          }
+
+          setPage((prev) => prev + 1);
+        }
+      });
+
+      if (node) observer.current.observe(node);
+    },
+    [loading, page, fijalists.length]
+  );
 
   return (
     <main className="min-h-screen bg-white">
@@ -62,7 +66,9 @@ export default function Catalog() {
         <header className="flex items-center justify-between mb-4">
           {/* search bar */}
           <form role="search" className="relative flex-1 max-w-xl">
-            <label htmlFor="search-input" className="sr-only">Search lists</label>
+            <label htmlFor="search-input" className="sr-only">
+              Search lists
+            </label>
             <input
               id="search-input"
               type="search"
@@ -70,33 +76,70 @@ export default function Catalog() {
               className="w-full pl-10 pr-4 py-2 border rounded-full bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
             <div className="absolute left-3 top-2.5" aria-hidden="true">
-              <svg className="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              <svg
+                className="h-5 w-5 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
               </svg>
             </div>
           </form>
 
           {/* view controls */}
-          <nav className="flex items-center space-x-4" aria-label="View options">
+          <nav
+            className="flex items-center space-x-4"
+            aria-label="View options"
+          >
             <div className="flex space-x-2">
-              <button 
-                onClick={() => setViewMode('grid')}
+              <button
+                onClick={() => setViewMode("grid")}
                 aria-label="Grid view"
-                aria-pressed={viewMode === 'grid'}
-                className={`p-2 rounded-lg ${viewMode === 'grid' ? 'bg-gray-200' : 'hover:bg-gray-100'}`}
+                aria-pressed={viewMode === "grid"}
+                className={`p-2 rounded-lg ${
+                  viewMode === "grid" ? "bg-gray-200" : "hover:bg-gray-100"
+                }`}
               >
-                <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"
+                  />
                 </svg>
               </button>
-              <button 
-                onClick={() => setViewMode('map')}
+              <button
+                onClick={() => setViewMode("map")}
                 aria-label="Map view"
-                aria-pressed={viewMode === 'map'}
-                className={`p-2 rounded-lg ${viewMode === 'map' ? 'bg-gray-200' : 'hover:bg-gray-100'}`}
+                aria-pressed={viewMode === "map"}
+                className={`p-2 rounded-lg ${
+                  viewMode === "map" ? "bg-gray-200" : "hover:bg-gray-100"
+                }`}
               >
-                <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"
+                  />
                 </svg>
               </button>
             </div>
@@ -104,8 +147,15 @@ export default function Catalog() {
         </header>
 
         {/* filter nav */}
-        <nav className="flex space-x-2 mb-6 overflow-x-auto pb-2" aria-label="List filters">
-          <button role="tab" aria-selected="false" className="px-4 py-2 text-sm font-medium bg-gray-100 rounded-full hover:bg-gray-200">
+        <nav
+          className="flex space-x-2 mb-6 overflow-x-auto pb-2"
+          aria-label="List filters"
+        >
+          <button
+            role="tab"
+            aria-selected="false"
+            className="px-4 py-2 text-sm font-medium bg-gray-100 rounded-full hover:bg-gray-200"
+          >
             Filters
           </button>
           <button className="px-4 py-2 text-sm font-medium bg-gray-100 rounded-full hover:bg-gray-200">
@@ -126,47 +176,69 @@ export default function Catalog() {
         </nav>
 
         {/* create new collection button */}
-        <button 
+        <button
           className="w-full mb-6 px-4 py-3 text-sm font-medium text-purple-600 bg-purple-50 rounded-lg hover:bg-purple-100 flex items-center justify-center"
           aria-label="Create new collection"
         >
-          <svg className="h-5 w-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+          <svg
+            className="h-5 w-5 mr-2"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+            />
           </svg>
           Create New Collection
         </button>
 
-        {/* main masonry gruid */}
-        <section 
+        {/* main masonry grid */}
+        <section
           className="columns-1 sm:columns-2 md:columns-3 gap-4 space-y-4"
           aria-label="List grid"
         >
           {items.map((item, index) => (
-            <article 
+            <article
               key={item.id}
               ref={index === items.length - 1 ? lastItemRef : null}
               className="break-inside-avoid mb-4"
             >
               <div className="bg-white rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow">
                 <figure className="relative">
-                  <img 
-                    src={`https://source.unsplash.com/random/${Math.floor(Math.random() * 100 + 300)}x${item.height * 16}?sig=${item.id}`}
-                    alt={`List ${item.id + 1}`}
+                  <img
+                    src={item.cover_image}
+                    alt={item.title}
                     className="w-full h-full object-cover"
-                    style={{ height: `${item.height}rem` }}
+                    style={{ height: `${getRandomHeight()}rem` }}
                   />
-                  <button 
+                  <button
                     className="absolute top-2 right-2 p-2 rounded-full bg-white/80 hover:bg-white"
                     aria-label="Add to favorites"
                   >
-                    <svg className="h-5 w-5 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                    <svg
+                      className="h-5 w-5 text-gray-700"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+                      />
                     </svg>
                   </button>
                 </figure>
                 <div className="p-4">
-                  <h2 className="font-semibold text-lg mb-1">List Title {item.id + 1}</h2>
-                  <p className="text-sm text-gray-500">Brief description of the list goes here.</p>
+                  <h2 className="font-semibold text-lg mb-1">{item.title}</h2>
+                  <p className="text-sm text-gray-500">{item.description}</p>
                 </div>
               </div>
             </article>
@@ -175,13 +247,13 @@ export default function Catalog() {
 
         {/* loading state */}
         {loading && (
-          <div 
-            className="flex justify-center my-8" 
+          <div
+            className="flex justify-center my-8"
             role="status"
-            aria-label="Loading more listss"
+            aria-label="Loading more lists"
           >
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
-            <span className="sr-only">Loading more listss...</span>
+            <span className="sr-only">Loading more lists...</span>
           </div>
         )}
       </section>

--- a/frontend/app/routes/catalog.tsx
+++ b/frontend/app/routes/catalog.tsx
@@ -1,16 +1,30 @@
-// TODO: upon clicking on a list, it should show up as a modal so we don't lose our position on the page
-// or similar to Pinterest where it opens up a new view, and recommends similar things underneath
-
 import { useState } from "react";
 import useData from "../hooks/useData";
 import type { Fijalist } from "~/lib/types";
 import useInfiniteScroll from "../hooks/useInfiniteScroll";
 import MasonryGrid from "../components/MasonryGrid";
 import LoadingSpinner from "../components/LoadingSpinner";
+import Modal from "../components/Modal";
+import FijalistPreview from "../components/FijalistPreview";
 
 export default function Catalog() {
   const { fijalists, isLoading } = useData();
   const [viewMode, setViewMode] = useState("grid"); // grid or map view
+  
+  // modal state
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const [selectedFijalist, setSelectedFijalist] = useState<Fijalist | null>(null);
+  
+  // open preview modal with selected fijalist
+  const handleFijalistClick = (fijalist: Fijalist) => {
+    setSelectedFijalist(fijalist);
+    setIsPreviewOpen(true);
+  };
+  
+  // close the preview modal
+  const handleClosePreview = () => {
+    setIsPreviewOpen(false);
+  };
   
   const { 
     displayedItems: items, 
@@ -178,13 +192,31 @@ export default function Catalog() {
         {/* main masonry grid */}
         {items.length > 0 && (
           <section aria-label="List grid">
-            <MasonryGrid items={items} lastItemRef={lastItemRef} />
+            <MasonryGrid 
+              items={items} 
+              lastItemRef={lastItemRef} 
+              onItemClick={handleFijalistClick}
+            />
           </section>
         )}
 
         {/* loading state */}
         {loading && <LoadingSpinner />}
       </section>
+      
+      {/* fijalist preview modal */}
+      <Modal 
+        isOpen={isPreviewOpen} 
+        onClose={handleClosePreview}
+        title="List Preview"
+      >
+        {selectedFijalist && (
+          <FijalistPreview 
+            fijalist={selectedFijalist} 
+            onClose={handleClosePreview} 
+          />
+        )}
+      </Modal>
     </main>
   );
 }

--- a/frontend/app/routes/catalog.tsx
+++ b/frontend/app/routes/catalog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import useData from "../hooks/useData";
 import type { Fijalist } from "~/lib/types";
 import useInfiniteScroll from "../hooks/useInfiniteScroll";
@@ -6,10 +6,14 @@ import MasonryGrid from "../components/MasonryGrid";
 import LoadingSpinner from "../components/LoadingSpinner";
 import Modal from "../components/Modal";
 import FijalistPreview from "../components/FijalistPreview";
+import { useRestoreScrollPosition } from "../hooks/useScrollPosition";
 
 export default function Catalog() {
   const { fijalists, isLoading } = useData();
   const [viewMode, setViewMode] = useState("grid"); // grid or map view
+  
+  // restore scroll position when returning to catalog -- is this something we want to implement???
+  useRestoreScrollPosition("catalog");
   
   // modal state
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);

--- a/frontend/app/routes/catalog.tsx
+++ b/frontend/app/routes/catalog.tsx
@@ -4,6 +4,7 @@
 // or similar to Pinterest where it opens up a new view, and recommends similar things underneath
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import { Link } from "react-router";
 import useData from "../hooks/useData";
 import type { Fijalist } from "~/lib/types";
 
@@ -208,39 +209,45 @@ export default function Catalog() {
               ref={index === items.length - 1 ? lastItemRef : null}
               className="break-inside-avoid mb-4"
             >
-              <div className="bg-white rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow">
-                <figure className="relative">
-                  <img
-                    src={item.cover_image}
-                    alt={item.title}
-                    className="w-full h-full object-cover"
-                    style={{ height: `${getRandomHeight()}rem` }}
-                  />
-                  <button
-                    className="absolute top-2 right-2 p-2 rounded-full bg-white/80 hover:bg-white"
-                    aria-label="Add to favorites"
-                  >
-                    <svg
-                      className="h-5 w-5 text-gray-700"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                      aria-hidden="true"
+              <Link to={`/fijalist/${item.id}`}>
+                <div className="bg-white rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow">
+                  <figure className="relative">
+                    <img
+                      src={item.cover_image}
+                      alt={item.title}
+                      className="w-full h-full object-cover"
+                      style={{ height: `${getRandomHeight()}rem` }}
+                    />
+                    <button
+                      className="absolute top-2 right-2 p-2 rounded-full bg-white/80 hover:bg-white"
+                      aria-label="Add to favorites"
+                      onClick={(e) => {
+                        e.preventDefault(); // Prevent triggering the Link
+                        // Add favorite functionality here
+                      }}
                     >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="2"
-                        d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
-                      />
-                    </svg>
-                  </button>
-                </figure>
-                <div className="p-4">
-                  <h2 className="font-semibold text-lg mb-1">{item.title}</h2>
-                  <p className="text-sm text-gray-500">{item.description}</p>
+                      <svg
+                        className="h-5 w-5 text-gray-700"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth="2"
+                          d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+                        />
+                      </svg>
+                    </button>
+                  </figure>
+                  <div className="p-4">
+                    <h2 className="font-semibold text-lg mb-1">{item.title}</h2>
+                    <p className="text-sm text-gray-500">{item.description}</p>
+                  </div>
                 </div>
-              </div>
+              </Link>
             </article>
           ))}
         </section>

--- a/frontend/app/routes/fijalist.tsx
+++ b/frontend/app/routes/fijalist.tsx
@@ -7,6 +7,7 @@ import MasonryGrid from "../components/MasonryGrid";
 import LoadingSpinner from "../components/LoadingSpinner";
 import Modal from "../components/Modal";
 import FijalistPreview from "../components/FijalistPreview";
+import { saveScrollPosition } from "../hooks/useScrollPosition";
 
 export default function FijalistDetail() {
   const { id } = useParams<{ id: string }>();
@@ -62,6 +63,11 @@ export default function FijalistDetail() {
     pageSize: 6
   });
 
+  // handle click on the back button to save scroll position
+  const handleBackClick = () => {
+    saveScrollPosition("catalog");
+  };
+
   // display appropriate loading/error states
   if (isLoading) {
     return <div className="min-h-screen flex items-center justify-center">Loading data...</div>;
@@ -90,6 +96,7 @@ export default function FijalistDetail() {
         <Link 
           to="/catalog" 
           className="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700"
+          onClick={handleBackClick}
         >
           Back to Catalog
         </Link>
@@ -108,6 +115,7 @@ export default function FijalistDetail() {
         <Link 
           to="/catalog" 
           className="inline-flex items-center mb-6 text-purple-600 hover:text-purple-800"
+          onClick={handleBackClick}
         >
           <svg 
             className="w-5 h-5 mr-2" 

--- a/frontend/app/routes/fijalist.tsx
+++ b/frontend/app/routes/fijalist.tsx
@@ -1,0 +1,200 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Link, useParams } from "react-router";
+import useData from "../hooks/useData";
+import type { Fijalist } from "~/lib/types";
+
+export default function FijalistDetail() {
+  const { id } = useParams<{ id: string }>();
+  const { fijalists } = useData();
+  
+  const [currentFijalist, setCurrentFijalist] = useState<Fijalist | null>(null);
+  
+  // to display related lists w infinite scrolling
+  const [relatedLists, setRelatedLists] = useState<Fijalist[]>([]);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const observer = useRef<IntersectionObserver | null>(null);
+
+  // get current fijalist based on ID from route params
+  useEffect(() => {
+    if (id) {
+      const fijalist = fijalists.find(item => item.id === id);
+      setCurrentFijalist(fijalist || null);
+    }
+  }, [id, fijalists]);
+
+  // function to find related lists based on tags
+  const findRelatedLists = useCallback(() => {
+    if (!currentFijalist || !currentFijalist.tags) return [];
+    
+    const currentTags = currentFijalist.tags.map(tag => tag.id);
+    
+    // find other fijalists with at least one matching tag, excluding current one
+    return fijalists.filter(item => 
+      item.id !== currentFijalist.id && 
+      item.tags && 
+      item.tags.some(tag => currentTags.includes(tag.id))
+    );
+  }, [currentFijalist, fijalists]);
+
+  const fetchRelatedItems = useCallback(async () => {
+    if (!currentFijalist) return;
+    
+    setLoading(true);
+    
+    await new Promise(resolve => setTimeout(resolve, 500));
+    
+    const allRelated = findRelatedLists();
+    const newItems = allRelated.slice(0, page * 6);
+    
+    setRelatedLists(newItems);
+    setLoading(false);
+  }, [currentFijalist, findRelatedLists, page]);
+
+  // to load related lists when current fijalist changes
+  useEffect(() => {
+    fetchRelatedItems();
+  }, [fetchRelatedItems, page]);
+
+  // same infinite scroll logic as catalog
+  const lastItemRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (loading) return;
+      
+      if (observer.current) observer.current.disconnect();
+      
+      observer.current = new IntersectionObserver(entries => {
+        if (entries[0].isIntersecting) {
+          const allRelated = findRelatedLists();
+          if (page * 6 >= allRelated.length) {
+            observer.current?.disconnect();
+            return;
+          }
+          
+          setPage(prev => prev + 1);
+        }
+      });
+      
+      if (node) observer.current.observe(node);
+    },
+    [loading, page, findRelatedLists]
+  );
+
+  const getRandomHeight = () => Math.floor(Math.random() * (30 - 10 + 1) + 10);
+
+  if (!currentFijalist) {
+    return <div className="min-h-screen flex items-center justify-center">Loading...</div>;
+  }
+
+  return (
+    <main className="min-h-screen bg-white">
+      <div className="max-w-7xl mx-auto px-4 py-8">
+        {/* back button */}
+        <Link 
+          to="/catalog" 
+          className="inline-flex items-center mb-6 text-purple-600 hover:text-purple-800"
+        >
+          <svg 
+            className="w-5 h-5 mr-2" 
+            fill="none" 
+            stroke="currentColor" 
+            viewBox="0 0 24 24"
+          >
+            <path 
+              strokeLinecap="round" 
+              strokeLinejoin="round" 
+              strokeWidth="2" 
+              d="M10 19l-7-7m0 0l7-7m-7 7h18" 
+            />
+          </svg>
+          Back to Catalog
+        </Link>
+
+        {/* main fijalist content */}
+        <section className="mb-12">
+          <div className="bg-white rounded-lg overflow-hidden shadow-md">
+            {/* cover image */}
+            <div className="relative h-72 md:h-96">
+              <img 
+                src={currentFijalist.cover_image || 'https://via.placeholder.com/800x400?text=No+Image'} 
+                alt={currentFijalist.title}
+                className="w-full h-full object-cover"
+              />
+            </div>
+            
+            <div className="p-6">
+              <h1 className="text-3xl font-bold mb-4">{currentFijalist.title}</h1>
+              
+              {/* tag */}
+              {currentFijalist.tags && currentFijalist.tags.length > 0 && (
+                <div className="flex flex-wrap gap-2 mb-4">
+                  {currentFijalist.tags.map(tag => (
+                    <span 
+                      key={tag.id}
+                      className="px-3 py-1 bg-purple-100 text-purple-800 text-sm rounded-full"
+                    >
+                      {tag.name}
+                    </span>
+                  ))}
+                </div>
+              )}
+              
+              <p className="text-gray-600 mb-6">{currentFijalist.description}</p>
+              
+              {/* main list */}
+              <div className="prose max-w-none">
+                <div className="whitespace-pre-wrap">{currentFijalist.content}</div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* related lists section */}
+        {relatedLists.length > 0 && (
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold mb-6">Related Lists</h2>
+            
+            {/* same masonry grid as catalog */}
+            <div className="columns-1 sm:columns-2 md:columns-3 gap-4 space-y-4">
+              {relatedLists.map((item, index) => (
+                <article
+                  key={item.id}
+                  ref={index === relatedLists.length - 1 ? lastItemRef : null}
+                  className="break-inside-avoid mb-4"
+                >
+                  <Link to={`/fijalist/${item.id}`}>
+                    <div className="bg-white rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow">
+                      <figure className="relative">
+                        <img
+                          src={item.cover_image || 'https://via.placeholder.com/400x300?text=No+Image'}
+                          alt={item.title}
+                          className="w-full h-full object-cover"
+                          style={{ height: `${getRandomHeight()}rem` }}
+                        />
+                      </figure>
+                      <div className="p-4">
+                        <h3 className="font-semibold text-lg mb-1">{item.title}</h3>
+                        <p className="text-sm text-gray-500">{item.description}</p>
+                      </div>
+                    </div>
+                  </Link>
+                </article>
+              ))}
+            </div>
+            
+            {loading && (
+              <div
+                className="flex justify-center my-8"
+                role="status"
+                aria-label="Loading more lists"
+              >
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+                <span className="sr-only">Loading more lists...</span>
+              </div>
+            )}
+          </section>
+        )}
+      </div>
+    </main>
+  );
+} 

--- a/frontend/app/routes/fijalist.tsx
+++ b/frontend/app/routes/fijalist.tsx
@@ -5,12 +5,29 @@ import type { Fijalist } from "~/lib/types";
 import useInfiniteScroll from "../hooks/useInfiniteScroll";
 import MasonryGrid from "../components/MasonryGrid";
 import LoadingSpinner from "../components/LoadingSpinner";
+import Modal from "../components/Modal";
+import FijalistPreview from "../components/FijalistPreview";
 
 export default function FijalistDetail() {
   const { id } = useParams<{ id: string }>();
   const { fijalists, isLoading } = useData();
   
   const [currentFijalist, setCurrentFijalist] = useState<Fijalist | null>(null);
+  
+  // modal state for previewing related lists
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const [selectedFijalist, setSelectedFijalist] = useState<Fijalist | null>(null);
+  
+  // handle clicking on a related list
+  const handleRelatedListClick = (fijalist: Fijalist) => {
+    setSelectedFijalist(fijalist);
+    setIsPreviewOpen(true);
+  };
+  
+  // close the preview modal
+  const handleClosePreview = () => {
+    setIsPreviewOpen(false);
+  };
 
   // get current fijalist based on ID from route params
   useEffect(() => {
@@ -152,14 +169,30 @@ export default function FijalistDetail() {
           <section className="mb-12">
             <h2 className="text-2xl font-bold mb-6">Related Lists</h2>
             
-            {/* masonry grid */}
-            <MasonryGrid items={relatedLists} lastItemRef={lastItemRef} />
+            <MasonryGrid 
+              items={relatedLists} 
+              lastItemRef={lastItemRef} 
+              onItemClick={handleRelatedListClick}
+            />
             
-            {/* loading state */}
             {loading && <LoadingSpinner />}
           </section>
         )}
       </div>
+      
+      {/* modal for previewing related lists */}
+      <Modal 
+        isOpen={isPreviewOpen} 
+        onClose={handleClosePreview}
+        title="List Preview"
+      >
+        {selectedFijalist && (
+          <FijalistPreview 
+            fijalist={selectedFijalist} 
+            onClose={handleClosePreview} 
+          />
+        )}
+      </Modal>
     </main>
   );
 } 

--- a/frontend/app/utils/display.ts
+++ b/frontend/app/utils/display.ts
@@ -1,0 +1,4 @@
+// to generate a random height for masonry grid items
+export function getRandomHeight(min = 10, max = 30) {
+  return Math.floor(Math.random() * (max - min + 1) + min);
+} 


### PR DESCRIPTION
# Key Changes
### FijaList Page View
- Implemented UI for displaying FijaList 
- Added a section for related lists based on common tags
  - This is buggy right now (see demo video in Slack), so it's still a WIP

### Modal/FijaList Preview
- Created a reusable modal component used for previewing the fija list before going to the actual fijalist view
- This modal allows us to show a highlevel overview of a selected FijaList without leaving the catalog page
- Modal has a link to be able to view the full FijaList

### Updated Filter Bar
- Filter bar no works as a tag-based filtering system
- Can select multiple tags at a time
- Organized the [current tags we drafted](https://docs.google.com/document/d/1q0uwwZHmoXpCaU0M8qhdor28S5M2_G_5jTbXWRkn4eo/edit?tab=t.0#heading=h.ew90xfiemu2c) into expandable categories
- Added UI elements to display/manage the selected filters
- Can clear all filters

### Scroll Position Preservation (current WIP)
- I don't think this actually works yet, but it's hard to test right now without having a large database (I only seeded a few fake Fijalists to test the other parts of this PR)
- This feature is supposed to preserve the user's scroll position when navigating b/w the catalog and fijalist views

### Backend
- Routes should now be updated to work with these new frontend changes

# Demo
The file is too big so i will send in slack lol
