### PR TITLE
Formatting fijalist content in preview modal + full fijalist view

### DIFF
--- a/backend/app/auth/routes/login.py
+++ b/backend/app/auth/routes/login.py
@@ -7,6 +7,8 @@ from app.auth import auth
 
 @auth.route('/login', methods=['GET', 'POST'])
 def login():
+    """Authenticates a user with email and password.
+    Returns 400/401 for invalid requests or credentials, or user data with 200 on success."""
     data = request.get_json()
 
     missing_credentials = not data or not data.get(

--- a/backend/app/auth/routes/logout.py
+++ b/backend/app/auth/routes/logout.py
@@ -6,5 +6,7 @@ from app.auth import auth
 @auth.route('/logout', methods=['POST'])
 @login_required
 def logout():
+    """Logs out the currently authenticated user.
+    Requires an authenticated user and returns a success message with status code 200."""
     logout_user()
     return jsonify({"message": "Successfully logged out"}), 200

--- a/backend/app/auth/routes/signup.py
+++ b/backend/app/auth/routes/signup.py
@@ -7,6 +7,8 @@ from app.auth import auth
 
 @auth.route('/signup', methods=['GET', 'POST'])
 def signup():
+    """Registers a new user with the provided credentials.
+    Checks for existing email/username and returns 409 if taken or user data with 201 if successful."""
     data = request.get_json()
 
     email_taken = User.query.filter_by(email=data.get('email')).first()

--- a/backend/app/auth/routes/user.py
+++ b/backend/app/auth/routes/user.py
@@ -5,6 +5,8 @@ from app.auth import auth
 
 @auth.route('/user', methods=['GET'])
 def get_user_data():
+    """Retrieves the current user's data including profile info and collections.
+    Returns authenticated user's data or 'authenticated: False' if no user is logged in."""
     if current_user.is_authenticated:
         return jsonify({
             "id": current_user.id,

--- a/backend/app/main/routes/tags.py
+++ b/backend/app/main/routes/tags.py
@@ -5,6 +5,8 @@ from app.main import main
 
 @main.route('/tags', methods=['GET'])
 def get_tags():
+    """Retrieves all tags in the system.
+    Returns a JSON list of all tags with status code 200."""
     tags = Tag.query.all()
 
     return jsonify([{
@@ -14,6 +16,8 @@ def get_tags():
 
 @main.route('/tags/<int:id>', methods=['GET'])
 def get_tag(id):
+    """Retrieves a specific tag by ID.
+    Returns a 404 error if the tag doesn't exist or a JSON object with status code 200."""
     tag = Tag.query.get_or_404(id)
 
     return jsonify({
@@ -23,6 +27,8 @@ def get_tag(id):
 
 @main.route('/tags/<int:id>/fijalists', methods=['GET'])
 def get_tag_fijalists(id):
+    """Retrieves all FijaLists associated with a specific tag.
+    Returns a 404 error if the tag doesn't exist or a JSON list of FijaLists with status code 200."""
     tag = Tag.query.get_or_404(id)
 
     return jsonify([{
@@ -38,6 +44,8 @@ def get_tag_fijalists(id):
 
 @main.route('/tags', methods=['POST'])
 def create_tag():
+    """Creates a new tag from JSON data in the request body.
+    Expects a name field and returns the created tag with status code 201."""
     data = request.get_json()
 
     tag = Tag(name=data.get('name'))
@@ -53,6 +61,8 @@ def create_tag():
 
 @main.route('/tags/<int:id>', methods=['PUT'])
 def update_tag(id):
+    """Updates an existing tag with data from the request body.
+    Returns a 404 error if the tag doesn't exist or the updated tag with status code 200."""
     data = request.get_json()
 
     tag = Tag.query.get_or_404(id)
@@ -68,6 +78,8 @@ def update_tag(id):
 
 @main.route('/tags/<int:id>', methods=['DELETE'])
 def delete_tag(id):
+    """Deletes a tag by ID.
+    Returns a 404 error if the tag doesn't exist or success message with status code 200."""
     tag = Tag.query.get_or_404(id)
 
     db.session.delete(tag)

--- a/backend/app/models/fijalist.py
+++ b/backend/app/models/fijalist.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from app.extensions import db
+from wtforms import ValidationError
 
 class FijaList(db.Model):
     __tablename__ = 'fijalist'
@@ -36,3 +37,28 @@ class FijaList(db.Model):
             'created_at': self.created_at.isoformat() if self.created_at else None,
             'updated_at': self.updated_at.isoformat() if self.updated_at else None
         }
+        
+    @staticmethod
+    def validate_title(form, field):
+        """Validate that the title is between 3 and 255 characters."""
+        if not field.data:
+            raise ValidationError('Title is required')
+        if len(field.data) < 3:
+            raise ValidationError('Title must be at least 3 characters')
+        if len(field.data) > 255:
+            raise ValidationError('Title cannot exceed 255 characters')
+    
+    @staticmethod
+    def validate_description(form, field):
+        """Validate that the description is not too long."""
+        if field.data and len(field.data) > 500:
+            raise ValidationError('Description cannot exceed 500 characters')
+    
+    @staticmethod
+    def validate_content(form, field):
+        """Validate that content exists and is in proper format."""
+        if not field.data:
+            raise ValidationError('Content is required')
+        # this is just to check that thecontent is a dictionary (JSON object)
+        if not isinstance(field.data, dict):
+            raise ValidationError('Content must be a valid JSON object')

--- a/backend/app/models/tag.py
+++ b/backend/app/models/tag.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from app.extensions import db
+from wtforms import ValidationError
 
 class Tag(db.Model):
     __tablename__ = 'tag'
@@ -18,3 +19,42 @@ class Tag(db.Model):
             'id': self.id,
             'name': self.name
         }
+        
+    @staticmethod
+    def validate_name(form, field):
+        """Validate that the tag name is appropriate."""
+        if not field.data:
+            raise ValidationError('Tag name is required')
+        if len(field.data) < 2:
+            raise ValidationError('Tag name must be at least 2 characters')
+        if len(field.data) > 50:
+            raise ValidationError('Tag name cannot exceed 50 characters')
+        
+        # first - check if tag name contains only valid characters
+        # this basically allows alphanumeric chars and dashes/spaces
+        import re
+        if not re.match(r'^[a-zA-Z0-9\-\s]+$', field.data):
+            raise ValidationError('Tag name can only contain letters, numbers, spaces, and hyphens')
+            
+    @staticmethod
+    def validate_no_duplicate_tag(form, field):
+        """Validate that the tag doesn't already exist (case-insensitive)."""
+        from sqlalchemy import func
+        
+        existing_tag = Tag.query.filter(func.lower(Tag.name) == func.lower(field.data)).first()
+        
+        # if editing an existing tag, we need to exclude the current tag from the check
+        if existing_tag and getattr(form, 'id', None) != existing_tag.id:
+            raise ValidationError(f'A tag with the name "{field.data}" already exists')
+    
+    @staticmethod
+    def validate_tag_whitespace(form, field):
+        """Validate that the tag name doesn't have excessive whitespace."""
+        if field.data:
+            # check for leading/trailing whitespace
+            if field.data != field.data.strip():
+                raise ValidationError('Tag name should not have leading or trailing spaces')
+            
+            # check for multiple consecutive spaces
+            if '  ' in field.data:
+                raise ValidationError('Tag name should not have consecutive spaces')


### PR DESCRIPTION
## **How it works:**
1. Splits each entry at the hyphen (e.g., "Dublin Writers Museum - Description")
2. Makes everything before the hyphen bold (the location name)
3. Displays everything after the hyphen as regular text (the description)
4. Shows only the first 3 items in preview mode with a "+more" indicator

## **Technical details:**
1. **Content Parsing:**
   - First tries to parse content as JSON array using `JSON.parse()`
   - If that fails, uses regex to identify title-description patterns in plain text

2. **Title-Description Separation:**
   - Uses regex pattern `.split(/ - (.+)/)` to split at the first hyphen
   - Captures everything before as title and after as description
   - Applies `.trim()` to remove extra spaces and `.replace(/,$/, '')` to remove trailing commas

3. **Display Components:**
   - Renders titles in `<h3>` tags with `font-bold` class
   - Descriptions go in `<p>` tags with regular styling
   - Each pair is wrapped in its own `<div>` with proper spacing
   - For preview mode, limits to 3 items and truncates long descriptions with `truncateContent()`